### PR TITLE
Allow commands to be excuted before worker exec (i.e sourcing env vars)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ celery_bin: celery                                    # Celery executable. Ex:
                                                       # celery_bin: /path/to/virtualenv/bin/celery
                                                       # celery_bin: "python /path/to/django/manage.py celery --settings=settings"
                                                       # celery_bin: "/path/to/virtualenv/python /path/to/django/manage.py celery --settings=settings"
-                  
+
 
 celery_run:                                           # Start celery. See default values below. Ex:
 - { action: worker }                                  # - { action: worker, queue: 'hard', concurrency: 4, loglevel: debug, user=deploy }
@@ -20,6 +20,7 @@ celery_run:                                           # Start celery. See defaul
                                                       # - { action: worker, opts: '--settings=settings.local' }
 
 celery_concurrency: 1                                 # Set default concurence level
+celery_pre_exec: []                                   # commands to execute before starting celery, e.g (`. /path/to/env_vars`)
 celery_env: {}                                        # Default environment variables
 
 # Directories

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -39,7 +39,7 @@ respawn
 script
 
     {# Run any pre-exec commands we have defined, e.g `. /path/to/your/env_vars/.env`#}
-    {% for line in celery_pre_exec %}
+    {% for line in item.celery_pre_exec|default(celery_pre_exec) %}
     {{line}}
     {% endfor %}
 

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -36,7 +36,14 @@ kill timeout 20
 limit nofile 65536 65536
 respawn
 
-exec {{celery_bin}} {{item.action}} $CELERY_QUEUE_ARG $CELERY_CONCURRENCY_ARG \
+script
+
+    {# Run any pre-exec commands we have defined, e.g `. /path/to/your/env_vars/.env`#}
+    {% for line in celery_pre_exec %}
+    {{line}}
+    {% endfor %}
+
+    exec {{celery_bin}} {{item.action}} $CELERY_QUEUE_ARG $CELERY_CONCURRENCY_ARG \
                                     --pidfile="$CELERY_PID_FILE" \
                                     --logfile="$CELERY_LOG_FILE" \
                                     --loglevel="$CELERY_LOG_LEVEL" \
@@ -44,3 +51,5 @@ exec {{celery_bin}} {{item.action}} $CELERY_QUEUE_ARG $CELERY_CONCURRENCY_ARG \
                                     --workdir="$CELERY_CHDIR" \
                                     --uid="$USER" \
                                     --gid="$GROUP" {% if item.action == 'beat' %}--schedule={{celery_beat_dbfile}}{% endif %}
+
+end script


### PR DESCRIPTION
Hi, I wanted to use this role for running celery on my server, and needed to get some env vars in for the workers to have access to.. I noticed that @JoseKilo had added and `celery_env` var for this purpose, but my env vars are a little more complex than that, and was hoping to source my `postactivate` script instead (also to avoid duplication).. so ive added a `celery_pre_exec` arg that allows users to execute arbitrary commands before the `exec` of the worker... the upstart script for my use case is:

```
script
    . /path/to/my/virtualenv/postactivate
    exec celery_worker command ...
end script
```

Its a non-breaking change, and I've confirmed that the upstart job can be started/stopped successfully with this change..

Thanks
